### PR TITLE
Travis-CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - 1.8.x
   - 1.9.x
   - master
 
@@ -12,7 +11,7 @@ before_install:
   - go get -v github.com/mitchellh/gox
 
 install:
-  - gox -output "dist/{{.OS}}_{{.Arch}}_{{.Dir}}" ./...
+  - gox -output "dist/{{.Dir}}_{{.OS}}_{{.Arch}}" ./...
 
 after_success:
-  -  ghr --username fhalim --token $GITHUB_TOKEN --replace --prerelease --debug pre-release dist/
+  -  ghr -u ${GITHUB_USERNAME} -t ${GITHUB_TOKEN} -replace -prerelease --debug pre-release dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ go:
   - 1.9.x
   - master
 
-before-install:
+before_install:
   - go get -v github.com/Masterminds/glide 
   - make get-deps
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ go:
 before_install:
   - go get -v github.com/Masterminds/glide 
   - make get-deps
+  - go get -v github.com/tcnksm/ghr
+  - go get -v https://github.com/mitchellh/gox
 
 install:
-  - make build
+  - gox -output "dist/{{.OS}}_{{.Arch}}_{{.Dir}}" ./...
+
+after_success:
+  -  ghr --username fhalim --token $GITHUB_TOKEN --replace --prerelease --debug pre-release dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,12 @@ language: go
 
 go:
   - 1.8.x
+  - 1.9.x
   - master
 
-install:
+before-install:
   - go get -v github.com/Masterminds/glide 
   - make get-deps
+
+install:
+  - make build

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - go get -v github.com/Masterminds/glide 
   - make get-deps
   - go get -v github.com/tcnksm/ghr
-  - go get -v https://github.com/mitchellh/gox
+  - go get -v github.com/mitchellh/gox
 
 install:
   - gox -output "dist/{{.OS}}_{{.Arch}}_{{.Dir}}" ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN make get-deps
 RUN go get -v github.com/mindis/prom2click
 FROM alpine:3.5
 COPY --from=build /go/bin/prom2click /usr/local/bin/prom2click
-ENTRYPOINT "/usr/local/bin/prom2click"
+ENTRYPOINT ["/usr/local/bin/prom2click"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,5 @@ RUN make get-deps
 RUN go get -v github.com/mindis/prom2click
 FROM alpine:3.5
 COPY --from=build /go/bin/prom2click /usr/local/bin/prom2click
+COPY --from=build /usr/local/go/lib/time/zoneinfo.zip /usr/local/go/lib/time/zoneinfo.zip
 ENTRYPOINT ["/usr/local/bin/prom2click"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.9.2-alpine AS build
+RUN apk update
+RUN apk add git
+RUN mkdir -p /go/src/github.com/mindis/prom2click
+ADD . /go/src/github.com/mindis/prom2click
+RUN go get -v github.com/Masterminds/glide
+WORKDIR /go/src/github.com/mindis/prom2click 
+RUN apk add make
+RUN make get-deps
+RUN go get -v github.com/mindis/prom2click
+FROM alpine:3.5
+COPY --from=build /go/bin/prom2click /usr/local/bin/prom2click
+ENTRYPOINT "/usr/local/bin/prom2click"


### PR DESCRIPTION
Corrected the Travis builds to produce artifacts and publish them as github artifacts. Also added a Dockerfile for building an alpine image with prom2click (validated at https://hub.docker.com/r/fhalim/prom2click/).