### PR TITLE
add one more condition for data querying to limit the end of date field

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -20,7 +20,7 @@ type p2cReader struct {
 func (r *p2cReader) getTimePeriod(query *remote.Query) (string, string, error) {
 
 	var tselSQL = "SELECT COUNT() AS CNT, (intDiv(toUInt32(ts), %d) * %d) * 1000 as t"
-	var twhereSQL = "WHERE date >= toDate(%d) AND ts >= toDateTime(%d) AND ts <= toDateTime(%d)"
+	var twhereSQL = "WHERE date >= toDate(%d) AND ts >= toDateTime(%d) AND ts <= toDateTime(%d) AND date <= toDate(%d)"
 	var err error
 	tstart := query.StartTimestampMs / 1000
 	tend := query.EndTimestampMs / 1000
@@ -45,7 +45,7 @@ func (r *p2cReader) getTimePeriod(query *remote.Query) (string, string, error) {
 	}
 
 	selectSQL := fmt.Sprintf(tselSQL, taggr, taggr)
-	whereSQL := fmt.Sprintf(twhereSQL, tstart, tstart, tend)
+	whereSQL := fmt.Sprintf(twhereSQL, tstart, tstart, tend, tend)
 
 	return selectSQL, whereSQL, nil
 }


### PR DESCRIPTION
When we use it for prometheus remote read, we met an issue that if we query data in a period long ago, it will cost  such a long time to get the result. 

Through the log, we found out that the query condition is as below:

"date >= toDate(1574999700) AND ts >= toDateTime(1574999700) and ts <= toDateTime(1575021600)"

But since the table should be partitioned by date, so, such query condition will seach all records from the start point till now.

So I made this change to make the query condition as below to guarantee clickhouse just search records in the specified range:

"date >= toDate(1574999700) AND ts >= toDateTime(1574999700) and ts <= toDateTime(1575021600) and date<=toDate(1575021600)"

